### PR TITLE
Update `./cc-test-reporte after-build` setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ after_script:
   - nyc report --reporter=lcov
   - codecov
   - cat ./coverage/lcov.info | codacy-coverage -f lcov -t $CODACY_PROJECT_TOKEN
-  - ./cc-test-reporter after-build -t lcov -p ./coverage --exit-code $TRAVIS_TEST_RESULT --debug || echo 'Skipping cc-test-reporter after-build...'
+  - ./cc-test-reporter after-build -t lcov --exit-code $TRAVIS_TEST_RESULT --debug || echo 'Skipping cc-test-reporter after-build...'


### PR DESCRIPTION
`--prefix` to remove from absolute paths in coverage payloads, to make them relative to the project root.

More info: https://github.com/codeclimate/test-reporter/blob/ea3be0a05a7b87e48ffc0279710236d23d4a5181/man/cc-test-reporter-format-coverage.1.md#-p---prefix-path